### PR TITLE
Get by tag

### DIFF
--- a/src/collection/resources/_methods.js
+++ b/src/collection/resources/_methods.js
@@ -6,7 +6,7 @@ module.exports = (ObjectClass) => ({
       page,
       size,
       type: 'get',
-      urlParams: { ...urlParams, tags: tags ? tags.toString() : undefined },
+      urlParams: { ...urlParams, ...(tags && { tags: tags.toString() }) },
       json,
     }, done);
   },
@@ -47,7 +47,7 @@ module.exports = (ObjectClass) => ({
     page = 0, size = 100, tags, urlParams, json = false,
   } = {}, done) {
     return this.paginate({
-      page, size, type: 'get', action: 'search', urlParams: { ...urlParams, query, tags: tags ? tags.toString() : undefined }, json,
+      page, size, type: 'get', action: 'search', urlParams: { ...urlParams, query, ...(tags && { tags: tags.toString() }) }, json,
     }, done);
   },
 

--- a/src/collection/resources/_methods.js
+++ b/src/collection/resources/_methods.js
@@ -1,12 +1,12 @@
 module.exports = (ObjectClass) => ({
   getAll({
-    page, size, urlParams, json = false,
+    page, size, urlParams, tags, json = false,
   } = {}, done) {
     return this.paginate({
       page,
       size,
       type: 'get',
-      urlParams,
+      urlParams: { ...urlParams, tags: tags ? tags.toString() : undefined },
       json,
     }, done);
   },
@@ -44,10 +44,10 @@ module.exports = (ObjectClass) => ({
   },
 
   search(query, {
-    page = 0, size = 100, urlParams, json = false,
+    page = 0, size = 100, tags, urlParams, json = false,
   } = {}, done) {
     return this.paginate({
-      page, size, type: 'get', action: 'search', urlParams: { ...urlParams, query }, json,
+      page, size, type: 'get', action: 'search', urlParams: { ...urlParams, query, tags: tags ? tags.toString() : undefined }, json,
     }, done);
   },
 

--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -50,7 +50,9 @@ class Request {
   static serialize(params) {
     const str = [];
     Object.keys(params).forEach((key) => {
-      str.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`);
+      if (params[key] !== undefined) {
+        str.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`);
+      }
     });
     return str.length ? `?${str.join('&')}` : '';
   }

--- a/test/collection/product.js
+++ b/test/collection/product.js
@@ -43,7 +43,44 @@ describe('Product related tests', () => {
       done();
     });
   });
-
+  it('Should gets products with a tag in array', (done) => {
+    const [page, size] = [2, 100];
+    nock(endpoint)
+      .get('/products')
+      .query({ size, page, tags: 'searchTag' })
+      .reply(200, productsFile);
+    sa.products.get({ page, size, tags: ['searchTag'] }, (err, productPage) => {
+      assert.ok(Array.isArray(productPage.current));
+      assert.ok(productPage.current[0].constructor.name === 'Product');
+      done();
+    });
+  });
+  it('Should gets products with a tag in string', (done) => {
+    const [page, size] = [2, 100];
+    nock(endpoint)
+      .get('/products')
+      .query({ size, page, tags: 'searchTag' })
+      .reply(200, productsFile);
+    sa.products.get({ page, size, tags: 'searchTag' }, (err, productPage) => {
+      assert.ok(Array.isArray(productPage.current));
+      assert.ok(productPage.current[0].constructor.name === 'Product');
+      done();
+    });
+  });
+  it('Should search products with tags as an array', (done) => {
+    const [page, size] = [2, 100];
+    nock(endpoint)
+      .get('/products/search')
+      .query({
+        query: 'query', size, page, tags: 'searchTag1,searchTag2',
+      })
+      .reply(200, productsFile);
+    sa.products.search('query', { page, size, tags: ['searchTag1', 'searchTag2'] }, (err, productPage) => {
+      assert.ok(Array.isArray(productPage.current));
+      assert.ok(productPage.current[0].constructor.name === 'Product');
+      done();
+    });
+  });
   it('Should search subproducts for a product', (done) => {
     const [page, size] = [2, 100];
     nock(endpoint)


### PR DESCRIPTION
This pull request adds the possibility to get and search products with specified tags.

To get:
`await builton.products.get({ page, size, tags: 'productTag' })`

to search (with a query string):
`await builton.products.search('query', { page, size, tags: ['searchTag1', 'searchTag2'] })`

The `tag` argument can be either a string or a list.